### PR TITLE
Fix lack of directionality in best value retrievers

### DIFF
--- a/confopt/utils.py
+++ b/confopt/utils.py
@@ -179,14 +179,18 @@ def tabularize_configurations(configurations: List[Dict]) -> pd.DataFrame:
                 if type(element) not in types:
                     types.append(type(element))
             if str in types:
-                tabularized_configurations[column_name] = tabularized_configurations[
-                    column_name
-                ].fillna("None")
+                tabularized_configurations[column_name] = (
+                    tabularized_configurations[column_name]
+                    .infer_objects(copy=False)
+                    .fillna("None")
+                )
                 categorical_columns.append(column_name)
             elif float in types or int in types:
-                tabularized_configurations[column_name] = tabularized_configurations[
-                    column_name
-                ].fillna(0)
+                tabularized_configurations[column_name] = (
+                    tabularized_configurations[column_name]
+                    .infer_objects(copy=False)
+                    .fillna(0)
+                )
             else:
                 raise ValueError(
                     "Type other than 'str', 'int', 'float' was detected in 'None' handling."

--- a/examples/tabular_tuning.py
+++ b/examples/tabular_tuning.py
@@ -39,8 +39,8 @@ best_params = searcher.get_best_params()
 
 # 2. An initialized (but not trained) model object with the
 #    best hyperparameter configuration found during search
-model_init = searcher.get_best_model()
+model_init = searcher.configure_best_model()
 
 # 3. A trained model with the best hyperparameter configuration
 #    found during search
-model = searcher.get_best_fitted_model()
+model = searcher.fit_best_model()


### PR DESCRIPTION
- Methods that surfaced best parameters and models were always looking for the maximal performance metric, regardless of whether the search was maximizing or minimizing the metric (eg. classification accuracy vs. regression MSE). The MR fixes this.

Also: 
- Adds an extra fetcher method to return best performance metric values per search.
- Fixes pandas future warning.